### PR TITLE
Initial integration tests

### DIFF
--- a/commons/src/main/java/io/flowinquiry/modules/audit/AuditEntityDTO.java
+++ b/commons/src/main/java/io/flowinquiry/modules/audit/AuditEntityDTO.java
@@ -1,0 +1,22 @@
+package io.flowinquiry.modules.audit;
+
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class AuditEntityDTO {
+    private Long createdBy;
+    private String createdByUserName; // Fetching username instead of entity reference
+    private Instant createdAt;
+    private Long modifiedBy;
+    private String modifiedByUserName; // Fetching username instead of entity reference
+    private Instant modifiedAt;
+}

--- a/commons/src/main/java/io/flowinquiry/modules/teams/controller/WorkflowController.java
+++ b/commons/src/main/java/io/flowinquiry/modules/teams/controller/WorkflowController.java
@@ -1,6 +1,5 @@
 package io.flowinquiry.modules.teams.controller;
 
-import io.flowinquiry.modules.teams.domain.Workflow;
 import io.flowinquiry.modules.teams.service.WorkflowService;
 import io.flowinquiry.modules.teams.service.WorkflowTransitionService;
 import io.flowinquiry.modules.teams.service.dto.WorkflowDTO;
@@ -47,7 +46,7 @@ public class WorkflowController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Workflow> getWorkflowById(@PathVariable("id") Long id) {
+    public ResponseEntity<WorkflowDTO> getWorkflowById(@PathVariable("id") Long id) {
         return workflowService
                 .getWorkflowById(id)
                 .map(ResponseEntity::ok)

--- a/commons/src/main/java/io/flowinquiry/modules/teams/service/WorkflowService.java
+++ b/commons/src/main/java/io/flowinquiry/modules/teams/service/WorkflowService.java
@@ -82,8 +82,8 @@ public class WorkflowService {
     }
 
     @Transactional(readOnly = true)
-    public Optional<Workflow> getWorkflowById(Long id) {
-        return workflowRepository.findById(id);
+    public Optional<WorkflowDTO> getWorkflowById(Long id) {
+        return workflowRepository.findById(id).map(workflowMapper::toDto);
     }
 
     @Transactional
@@ -96,7 +96,7 @@ public class WorkflowService {
                             return workflowMapper.toDto(workflowRepository.save(existingWorkflow));
                         })
                 .orElseThrow(
-                        () -> new IllegalArgumentException("Workflow not found with id: " + id));
+                        () -> new ResourceNotFoundException("Workflow not found with id: " + id));
     }
 
     /**

--- a/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/WorkflowDTO.java
+++ b/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/WorkflowDTO.java
@@ -1,5 +1,6 @@
 package io.flowinquiry.modules.teams.service.dto;
 
+import io.flowinquiry.modules.audit.AuditEntityDTO;
 import io.flowinquiry.modules.teams.domain.WorkflowVisibility;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -10,7 +11,7 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @AllArgsConstructor
 @SuperBuilder
-public class WorkflowDTO {
+public class WorkflowDTO extends AuditEntityDTO {
     private Long id;
     private String name;
     private String description;

--- a/commons/src/main/java/io/flowinquiry/security/SpringSecurityAuditorAware.java
+++ b/commons/src/main/java/io/flowinquiry/security/SpringSecurityAuditorAware.java
@@ -11,6 +11,6 @@ public class SpringSecurityAuditorAware implements AuditorAware<Long> {
 
     @Override
     public Optional<Long> getCurrentAuditor() {
-        return SecurityUtils.getCurrentUserLogin().map(UserKey::getId).or(() -> Optional.of(-1L));
+        return SecurityUtils.getCurrentUserLogin().map(UserKey::getId).or(Optional::empty);
     }
 }


### PR DESCRIPTION
## Description
Added integration tests for the Workflow Service to ensure its functionality and reliability.

## Changes Made

- Created a new DTO: `AuditEntityDTO`.
- Updated the default value for `auditor` to `Optional.empty` instead of `-1`.
  - Previously, when `createdBy` was set to `-1`, it caused an error while saving a workflow.
  - Since there is no valid user ID of `-1`, workflows could not be saved.
  - The new default value prevents this issue and ensures proper handling.