### PR TITLE
Update build.gradle to fix the warning 'No constructor parameter names discovered' from spring data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,9 @@ allprojects {
                     sourceCompatibility = 21
                     targetCompatibility = 21
                 }
+                tasks.withType(JavaCompile) {
+                    options.compilerArgs << "-parameters"
+                }
             }
 
             if (project.plugins.hasPlugin('java-library')) {


### PR DESCRIPTION
Fix the issue 
```
org.springframework.data.repository.query.ReturnedType.detectConstructorParameterNames:313 : No constructor parameter names discovered. Compile the affected code with '-parameters' instead or avoid its introspection
```

## Description
Root cause:
Spring Data is trying to determine the names of constructor parameters for a projection or DTO, but it cannot find them. This usually happens because Java does not retain parameter names at runtime unless compiled with the -parameters option.

## Changes Made
Update the gradle java compile to compile with `-parameters`