### PR TITLE
Require to save notifications first before sending to websocket

### DIFF
--- a/commons/src/main/java/io/flowinquiry/modules/teams/service/listener/NewTeamRequestCreatedNotificationEventListener.java
+++ b/commons/src/main/java/io/flowinquiry/modules/teams/service/listener/NewTeamRequestCreatedNotificationEventListener.java
@@ -93,15 +93,18 @@ public class NewTeamRequestCreatedNotificationEventListener {
                                 .isRead(false)
                                 .build();
 
-                messageTemplate.convertAndSendToUser(
-                        String.valueOf(user.getId()), "/queue/notifications", notification);
-
                 notifications.add(notification);
             }
         }
 
-        // Save all notifications in batch after WebSocket messages are sent
-        notificationRepository.saveAll(notifications);
+        List<Notification> savedNotifications = notificationRepository.saveAll(notifications);
+
+        for (Notification notification : savedNotifications) {
+            messageTemplate.convertAndSendToUser(
+                    String.valueOf(notification.getUser().getId()),
+                    "/queue/notifications",
+                    notification);
+        }
 
         ActivityLog activityLog =
                 ActivityLog.builder()

--- a/commons/src/main/java/io/flowinquiry/modules/teams/service/listener/TeamRequestCommentCreatedNotificationEventListener.java
+++ b/commons/src/main/java/io/flowinquiry/modules/teams/service/listener/TeamRequestCommentCreatedNotificationEventListener.java
@@ -103,6 +103,7 @@ public class TeamRequestCommentCreatedNotificationEventListener {
 
         List<UserWithTeamRoleDTO> usersInTeam =
                 teamRepository.findUsersByTeamId(teamRequest.getTeam().getId());
+
         List<Notification> notifications = new ArrayList<>();
 
         for (UserWithTeamRoleDTO user : usersInTeam) {
@@ -115,13 +116,18 @@ public class TeamRequestCommentCreatedNotificationEventListener {
                                 .isRead(false)
                                 .build();
 
-                messageTemplate.convertAndSendToUser(
-                        String.valueOf(user.getId()), "/queue/notifications", notification);
-
                 notifications.add(notification);
             }
         }
-        notificationRepository.saveAll(notifications);
+
+        List<Notification> savedNotifications = notificationRepository.saveAll(notifications);
+
+        for (Notification notification : savedNotifications) {
+            messageTemplate.convertAndSendToUser(
+                    String.valueOf(notification.getUser().getId()),
+                    "/queue/notifications",
+                    notification);
+        }
 
         ActivityLog activityLog =
                 ActivityLog.builder()


### PR DESCRIPTION
## Description
The current implementation pushes notifications to WebSocket before saving them to the database. As a result, the notifications sent to WebSocket do not have an ID yet, preventing users on the frontend from marking them as read.

## Changes Made
Do the changes when user save the new ticket or add comment to the existing ticket

## Additional Notes
<!-- Add any other context or information that reviewers may need. -->