### PR TITLE
feature(issue-78): Add second level cache support for hibernate

### DIFF
--- a/commons/build.gradle
+++ b/commons/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     api(libs.bundles.json)
     api(libs.bundles.shedlock)
     api(libs.bundles.spring.ai)
+    api(libs.redis.hibernate)
     api(libs.dot.env)
     api(libs.j2html)
 

--- a/commons/src/main/java/io/flowinquiry/config/hibernatecache/CaffeineHibernateConfig.java
+++ b/commons/src/main/java/io/flowinquiry/config/hibernatecache/CaffeineHibernateConfig.java
@@ -1,0 +1,14 @@
+package io.flowinquiry.config.hibernatecache;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+@Configuration
+@ConditionalOnProperty(
+        prefix = "flowinquiry.hibernate.second_level_cache",
+        name = "provider",
+        havingValue = "caffeine",
+        matchIfMissing = true)
+@PropertySource("classpath:hibernatecache/hibernate-caffeine.properties")
+public class CaffeineHibernateConfig {}

--- a/commons/src/main/java/io/flowinquiry/config/hibernatecache/RedisHibernateConfig.java
+++ b/commons/src/main/java/io/flowinquiry/config/hibernatecache/RedisHibernateConfig.java
@@ -1,0 +1,78 @@
+package io.flowinquiry.config.hibernatecache;
+
+import java.util.Map;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.cfg.AvailableSettings;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.redisson.hibernate.RedissonRegionFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+@Configuration
+@PropertySource("classpath:hibernatecache/hibernate-redis.properties")
+@EnableConfigurationProperties(RedisHibernateProps.class)
+@ConditionalOnProperty(
+        prefix = "flowinquiry.hibernate.second_level_cache",
+        name = "provider",
+        havingValue = "redis")
+public class RedisHibernateConfig {
+
+    @Bean
+    public HibernatePropertiesCustomizer hibernatePropertiesCustomizer(
+            RegionFactory regionFactory) {
+        return hibernateProperties -> {
+            hibernateProperties.put(AvailableSettings.USE_SECOND_LEVEL_CACHE, true);
+            hibernateProperties.put(AvailableSettings.CACHE_REGION_FACTORY, regionFactory);
+        };
+    }
+
+    @Bean
+    public RegionFactory redisRegionFactory(RedissonClient redissonClient) {
+        return new DynamicRedissonRegionFactory(redissonClient);
+    }
+
+    @Bean
+    public RedissonClient redissonClient(RedisHibernateProps props) {
+        Config config = new Config();
+        config.useSingleServer()
+                .setIdleConnectionTimeout(props.idleConnectionTimeout())
+                .setConnectTimeout(props.connectTimeout())
+                .setTimeout(props.timeout())
+                .setRetryAttempts(props.retryAttempts())
+                .setRetryInterval(props.retryInterval())
+                .setPassword(props.password())
+                .setSubscriptionsPerConnection(props.subscriptionsPerConnection())
+                .setClientName(props.clientName())
+                .setAddress(props.address())
+                .setSubscriptionConnectionMinimumIdleSize(
+                        props.subscriptionConnectionMinimumIdleSize())
+                .setSubscriptionConnectionPoolSize(props.subscriptionConnectionPoolSize())
+                .setConnectionMinimumIdleSize(props.connectionMinimumIdleSize())
+                .setConnectionPoolSize(props.connectionPoolSize())
+                .setDatabase(props.database())
+                .setDnsMonitoringInterval(props.dnsMonitoringInterval());
+        return Redisson.create(config);
+    }
+
+    public static class DynamicRedissonRegionFactory extends RedissonRegionFactory {
+
+        private final RedissonClient redissonClient;
+
+        public DynamicRedissonRegionFactory(RedissonClient redissonClient) {
+            this.redissonClient = redissonClient;
+        }
+
+        @Override
+        protected RedissonClient createRedissonClient(
+                StandardServiceRegistry registry, Map properties) {
+            return redissonClient;
+        }
+    }
+}

--- a/commons/src/main/java/io/flowinquiry/config/hibernatecache/RedisHibernateProps.java
+++ b/commons/src/main/java/io/flowinquiry/config/hibernatecache/RedisHibernateProps.java
@@ -1,0 +1,21 @@
+package io.flowinquiry.config.hibernatecache;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "flowinquiry.hibernate.second-level-cache.redis")
+public record RedisHibernateProps(
+        Integer idleConnectionTimeout,
+        Integer connectTimeout,
+        Integer timeout,
+        Integer retryAttempts,
+        Integer retryInterval,
+        String password,
+        Integer subscriptionsPerConnection,
+        String clientName,
+        String address,
+        Integer subscriptionConnectionMinimumIdleSize,
+        Integer subscriptionConnectionPoolSize,
+        Integer connectionMinimumIdleSize,
+        Integer connectionPoolSize,
+        Integer database,
+        Integer dnsMonitoringInterval) {}

--- a/commons/src/main/java/io/flowinquiry/modules/collab/domain/ActivityLog.java
+++ b/commons/src/main/java/io/flowinquiry/modules/collab/domain/ActivityLog.java
@@ -21,8 +21,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
 
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "fw_activity_log")
 @Getter
 @Setter

--- a/commons/src/main/java/io/flowinquiry/modules/collab/domain/Comment.java
+++ b/commons/src/main/java/io/flowinquiry/modules/collab/domain/Comment.java
@@ -14,8 +14,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
 
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "fw_comment")
 @Getter
 @Setter

--- a/commons/src/main/java/io/flowinquiry/modules/collab/domain/EntityWatcher.java
+++ b/commons/src/main/java/io/flowinquiry/modules/collab/domain/EntityWatcher.java
@@ -8,6 +8,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
 
 @Getter
 @Setter
@@ -15,6 +18,8 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(
         name = "fw_entity_watchers",
         indexes =

--- a/commons/src/main/java/io/flowinquiry/modules/collab/domain/Notification.java
+++ b/commons/src/main/java/io/flowinquiry/modules/collab/domain/Notification.java
@@ -18,8 +18,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
 
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "fw_notification")
 @Getter
 @Setter

--- a/commons/src/main/java/io/flowinquiry/modules/fss/domain/EntityAttachment.java
+++ b/commons/src/main/java/io/flowinquiry/modules/fss/domain/EntityAttachment.java
@@ -15,8 +15,13 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
 
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(
         name = "fw_entity_attachment",
         uniqueConstraints =

--- a/commons/src/main/java/io/flowinquiry/modules/shared/domain/DeduplicationCacheEntry.java
+++ b/commons/src/main/java/io/flowinquiry/modules/shared/domain/DeduplicationCacheEntry.java
@@ -9,8 +9,13 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
 
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "fw_deduplication_cache")
 @Getter
 @Setter

--- a/commons/src/main/java/io/flowinquiry/modules/teams/domain/EscalationTracking.java
+++ b/commons/src/main/java/io/flowinquiry/modules/teams/domain/EscalationTracking.java
@@ -11,8 +11,13 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.Instant;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
 
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "fw_escalation_tracking")
 public class EscalationTracking {
 

--- a/commons/src/main/java/io/flowinquiry/modules/teams/domain/Organization.java
+++ b/commons/src/main/java/io/flowinquiry/modules/teams/domain/Organization.java
@@ -14,8 +14,13 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
 
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "fw_organization")
 @Getter
 @Setter

--- a/commons/src/main/java/io/flowinquiry/modules/teams/domain/Team.java
+++ b/commons/src/main/java/io/flowinquiry/modules/teams/domain/Team.java
@@ -22,9 +22,14 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Formula;
+import org.springframework.cache.annotation.Cacheable;
 
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "fw_team")
 @Getter
 @Setter

--- a/commons/src/main/java/io/flowinquiry/modules/teams/domain/TeamRequest.java
+++ b/commons/src/main/java/io/flowinquiry/modules/teams/domain/TeamRequest.java
@@ -21,10 +21,15 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Formula;
+import org.springframework.cache.annotation.Cacheable;
 
 @EqualsAndHashCode(callSuper = false)
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "fw_team_request")
 @Getter
 @Setter

--- a/commons/src/main/java/io/flowinquiry/modules/teams/domain/TeamRequestConversationHealth.java
+++ b/commons/src/main/java/io/flowinquiry/modules/teams/domain/TeamRequestConversationHealth.java
@@ -13,8 +13,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
 
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "fw_team_request_conversation_health")
 @Getter
 @Setter

--- a/commons/src/main/java/io/flowinquiry/modules/teams/domain/TeamRole.java
+++ b/commons/src/main/java/io/flowinquiry/modules/teams/domain/TeamRole.java
@@ -11,8 +11,13 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
 
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "fw_team_role")
 @Getter
 @Setter

--- a/commons/src/main/java/io/flowinquiry/modules/teams/domain/TeamWorkflowSelection.java
+++ b/commons/src/main/java/io/flowinquiry/modules/teams/domain/TeamWorkflowSelection.java
@@ -12,8 +12,13 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
 
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "fw_team_workflow_selection")
 @Getter
 @Setter

--- a/commons/src/main/java/io/flowinquiry/modules/teams/domain/Workflow.java
+++ b/commons/src/main/java/io/flowinquiry/modules/teams/domain/Workflow.java
@@ -20,9 +20,14 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
 
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "fw_workflow")
 @Getter
 @Setter

--- a/commons/src/main/java/io/flowinquiry/modules/teams/domain/WorkflowAction.java
+++ b/commons/src/main/java/io/flowinquiry/modules/teams/domain/WorkflowAction.java
@@ -14,8 +14,13 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
 
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "fw_workflow_actions")
 @Getter
 @Setter

--- a/commons/src/main/java/io/flowinquiry/modules/teams/domain/WorkflowState.java
+++ b/commons/src/main/java/io/flowinquiry/modules/teams/domain/WorkflowState.java
@@ -15,8 +15,13 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
 
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "fw_workflow_state")
 @Getter
 @Setter

--- a/commons/src/main/java/io/flowinquiry/modules/teams/domain/WorkflowTransition.java
+++ b/commons/src/main/java/io/flowinquiry/modules/teams/domain/WorkflowTransition.java
@@ -14,6 +14,9 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
 
 @Getter
 @Setter
@@ -22,6 +25,8 @@ import lombok.Setter;
 @AllArgsConstructor
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "fw_workflow_transition")
 public class WorkflowTransition {
 

--- a/commons/src/main/java/io/flowinquiry/modules/teams/domain/WorkflowTransitionHistory.java
+++ b/commons/src/main/java/io/flowinquiry/modules/teams/domain/WorkflowTransitionHistory.java
@@ -17,8 +17,13 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
 
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "fw_workflow_transition_history")
 @Getter
 @Setter

--- a/commons/src/main/java/io/flowinquiry/modules/usermanagement/domain/Authority.java
+++ b/commons/src/main/java/io/flowinquiry/modules/usermanagement/domain/Authority.java
@@ -17,9 +17,14 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Formula;
+import org.springframework.cache.annotation.Cacheable;
 
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "fw_authority")
 @JsonIgnoreProperties(value = {"new", "id"})
 @Getter

--- a/commons/src/main/java/io/flowinquiry/modules/usermanagement/domain/AuthorityResourcePermission.java
+++ b/commons/src/main/java/io/flowinquiry/modules/usermanagement/domain/AuthorityResourcePermission.java
@@ -14,6 +14,9 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
 
 @Getter
 @Setter
@@ -22,6 +25,8 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "fw_authority_resource_permission")
 @IdClass(AuthorityResourcePermissionId.class) // Composite key class
 public class AuthorityResourcePermission {

--- a/commons/src/main/java/io/flowinquiry/modules/usermanagement/domain/Resource.java
+++ b/commons/src/main/java/io/flowinquiry/modules/usermanagement/domain/Resource.java
@@ -15,8 +15,13 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
 
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "fw_resource")
 @Getter
 @Setter

--- a/commons/src/main/java/io/flowinquiry/modules/usermanagement/domain/User.java
+++ b/commons/src/main/java/io/flowinquiry/modules/usermanagement/domain/User.java
@@ -34,9 +34,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
 
 /** A user. */
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "fw_user")
 @Getter
 @Setter

--- a/commons/src/main/java/io/flowinquiry/modules/usermanagement/domain/UserAuth.java
+++ b/commons/src/main/java/io/flowinquiry/modules/usermanagement/domain/UserAuth.java
@@ -19,8 +19,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
 
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "fw_user_auth")
 @Getter
 @Setter

--- a/commons/src/main/java/io/flowinquiry/modules/usermanagement/domain/UserAuthority.java
+++ b/commons/src/main/java/io/flowinquiry/modules/usermanagement/domain/UserAuthority.java
@@ -13,8 +13,13 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
 
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "fw_user_authority")
 @IdClass(UserAuthorityId.class) // Use a composite key
 @Getter

--- a/commons/src/main/java/io/flowinquiry/modules/usermanagement/domain/UserTeam.java
+++ b/commons/src/main/java/io/flowinquiry/modules/usermanagement/domain/UserTeam.java
@@ -14,8 +14,13 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
 
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(name = "fw_user_team")
 @Getter
 @Setter

--- a/commons/src/main/resources/hibernatecache/hibernate-caffeine.properties
+++ b/commons/src/main/resources/hibernatecache/hibernate-caffeine.properties
@@ -1,0 +1,2 @@
+spring.jpa.properties.hibernate.cache.region.factory_class=jcache
+spring.jpa.properties.hibernate.javax.cache.provider=com.github.benmanes.caffeine.jcache.spi.CaffeineCachingProvider

--- a/commons/src/main/resources/hibernatecache/hibernate-redis.properties
+++ b/commons/src/main/resources/hibernatecache/hibernate-redis.properties
@@ -1,0 +1,13 @@
+flowinquiry.hibernate.second-level-cache.redis.idleConnectionTimeout=10000
+flowinquiry.hibernate.second-level-cache.redis.connectTimeout=10000
+flowinquiry.hibernate.second-level-cache.redis.timeout=3000
+flowinquiry.hibernate.second-level-cache.redis.retryAttempts=3
+flowinquiry.hibernate.second-level-cache.redis.retryInterval=1500
+flowinquiry.hibernate.second-level-cache.redis.subscriptionsPerConnection=5
+flowinquiry.hibernate.second-level-cache.redis.address=redis://${REDIS_HOST:localhost}:${REDIS_PORT:6379}
+flowinquiry.hibernate.second-level-cache.redis.subscriptionConnectionMinimumIdleSize=1
+flowinquiry.hibernate.second-level-cache.redis.subscriptionConnectionPoolSize=50
+flowinquiry.hibernate.second-level-cache.redis.connectionMinimumIdleSize=10
+flowinquiry.hibernate.second-level-cache.redis.connectionPoolSize=64
+flowinquiry.hibernate.second-level-cache.redis.database=0
+flowinquiry.hibernate.second-level-cache.redis.dnsMonitoringInterval=5000

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,10 +18,12 @@ j2HtmlVersion = "1.6.0"
 shedlockVersion="6.0.1"
 jibVersion="3.4.4"
 caffeineVersion="3.2.0"
+redisHibernateVersion="3.45.0"
 
 [libraries]
 caffeine = {module="com.github.ben-manes.caffeine:caffeine", version.ref="caffeineVersion"}
 caffeine-jcache = {module="com.github.ben-manes.caffeine:jcache", version.ref="caffeineVersion"}
+redis-hibernate = {module="org.redisson:redisson-hibernate-6", version.ref="redisHibernateVersion"}
 jhipster-framework = { module = "tech.jhipster:jhipster-framework", version.ref = "jhisterVersion" }
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombokVersion" }
 liquibase = { module = "org.liquibase:liquibase-core", version.ref = "liquibaseVersion" }

--- a/server/src/test/java/io/flowinquiry/db/orm/cache/HibernateSecondLevelCacheTestIT.java
+++ b/server/src/test/java/io/flowinquiry/db/orm/cache/HibernateSecondLevelCacheTestIT.java
@@ -1,0 +1,42 @@
+package io.flowinquiry.db.orm.cache;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.flowinquiry.IntegrationTest;
+import io.flowinquiry.modules.teams.domain.Team;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+@IntegrationTest
+@TestPropertySource(
+        properties = "spring.jpa.properties.hibernate.cache.use_second_level_cache=true")
+public class HibernateSecondLevelCacheTestIT {
+
+    @Autowired SessionFactory sessionFactory;
+
+    @Test
+    public void multipleSessionCache() {
+
+        try (Session sessionOne = sessionFactory.openSession();
+                Session sessionTwo = sessionFactory.openSession()) {
+
+            final long entityId = 1L;
+            sessionFactory.getStatistics().setStatisticsEnabled(true);
+
+            sessionOne.get(Team.class, entityId);
+            long hitCountOne = sessionFactory.getStatistics().getSecondLevelCacheHitCount();
+            long missCountOne = sessionFactory.getStatistics().getSecondLevelCacheMissCount();
+            assertEquals(0, hitCountOne);
+            assertEquals(1, missCountOne);
+
+            sessionTwo.get(Team.class, entityId);
+            long hitCountTwo = sessionFactory.getStatistics().getSecondLevelCacheHitCount();
+            long missCountTwo = sessionFactory.getStatistics().getSecondLevelCacheMissCount();
+            assertEquals(2, hitCountTwo);
+            assertEquals(1, missCountTwo);
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR implements issue #78. It introduces second level caching for Hibernate. In order to reduce calls to the DB, second level caching is introduced to reduce stress on the DB and reduce latency. There are two cache providers, Caffeine by default and Redis an optional alternative.

## Changes Made

- Add Entity second level
- Add a property in order to control the hibernate second level cache providers: flowinquiry.hibernate.second_level_cache.provider
    - Possible values: {caffeine, redis}. Caffeine is chosen by default, even in absence of this property.
- Add a list of properties to control redis client configuration
- Add unit test

## Additional Notes
N/A