### PR TITLE
Fix team request navigation that relate to project ticket

### DIFF
--- a/commons/src/main/java/io/flowinquiry/modules/teams/repository/TeamRequestRepository.java
+++ b/commons/src/main/java/io/flowinquiry/modules/teams/repository/TeamRequestRepository.java
@@ -58,6 +58,7 @@ public interface TeamRequestRepository
             WHERE r.id = :requestId
         )
         AND tr.id < :requestId
+        AND tr.project is null
         ORDER BY tr.id DESC
             LIMIT 1
     """)
@@ -82,6 +83,7 @@ public interface TeamRequestRepository
             WHERE r.id = :requestId
         )
         AND tr.id > :requestId
+        AND tr.project is null
         ORDER BY tr.id ASC
             LIMIT 1
     """)


### PR DESCRIPTION
## Description
When the user navigates to the previous or next ticket, tickets belonging to a project within the team should be excluded

## Changes Made
<!-- List the main changes made in this PR. Use bullet points for clarity. -->

## Additional Notes
<!-- Add any other context or information that reviewers may need. -->