### PR TITLE
feat: Add field to the able to support estimation #101

### DIFF
--- a/commons/src/main/java/io/flowinquiry/modules/teams/domain/TShirtSize.java
+++ b/commons/src/main/java/io/flowinquiry/modules/teams/domain/TShirtSize.java
@@ -1,0 +1,14 @@
+package io.flowinquiry.modules.teams.domain;
+
+public enum TShirtSize {
+    S("Small"),
+    M("Medium"),
+    L("Large"),
+    XL("Extra-Large");
+
+    private final String description;
+
+    TShirtSize(String description) {
+        this.description = description;
+    }
+}

--- a/commons/src/main/java/io/flowinquiry/modules/teams/domain/TeamRequest.java
+++ b/commons/src/main/java/io/flowinquiry/modules/teams/domain/TeamRequest.java
@@ -2,19 +2,7 @@ package io.flowinquiry.modules.teams.domain;
 
 import io.flowinquiry.modules.audit.AbstractAuditingEntity;
 import io.flowinquiry.modules.usermanagement.domain.User;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Convert;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.ForeignKey;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -121,7 +109,8 @@ public class TeamRequest extends AbstractAuditingEntity<Long> {
     private ProjectEpic epic;
 
     @Column(nullable = false)
-    private Integer size;
+    @Enumerated(EnumType.STRING)
+    private TShirtSize size;
 
     @Column(nullable = false)
     private Integer estimate;

--- a/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/TeamRequestDTO.java
+++ b/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/TeamRequestDTO.java
@@ -1,5 +1,6 @@
 package io.flowinquiry.modules.teams.service.dto;
 
+import io.flowinquiry.modules.teams.domain.TShirtSize;
 import io.flowinquiry.modules.teams.domain.TicketChannel;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
@@ -51,7 +52,7 @@ public class TeamRequestDTO {
     private Instant modifiedAt;
     private int numberAttachments;
     private int numberWatchers;
-    private int size;
+    private TShirtSize size;
     private int estimate;
     private TeamRequestConversationHealthDTO conversationHealth;
 }

--- a/tools/liquibase/src/main/resources/config/liquibase/tenant/changelog/001_request_workflow_tables.xml
+++ b/tools/liquibase/src/main/resources/config/liquibase/tenant/changelog/001_request_workflow_tables.xml
@@ -925,6 +925,14 @@
 		<sql>SELECT setval('fw_activity_log_id_seq', (SELECT MAX(id) FROM
 			fw_activity_log));</sql>
 	</changeSet>
+	<changeSet id="001:13-update-fw_team_request" author="flowinquiry">
+		<update tableName="fw_team_request">
+			<column name="size" type="VARCHAR(15)">
+				<constraints nullable="true" />
+			</column>
+		</update>
+	</changeSet>
+
 
 
 </databaseChangeLog>


### PR DESCRIPTION
## Description
Adding changes required for Size and Estimation

## Changes Made
<!-- List the main changes made in this PR. Use bullet points for clarity. -->

## Additional Notes
<!-- Add any other context or information that reviewers may need. -->
I already found estimation and size fields in the changelog for liquidbase and in TeamRequest file, I have left the estimation as it is but instead of keeping the size as int I have created it to TShirtSize Enum, please take look, if you think this is okay to merge I will be adding integration and unit tests accordingly 